### PR TITLE
Fix link to global gitignore

### DIFF
--- a/dev-team.md
+++ b/dev-team.md
@@ -204,7 +204,7 @@ to exclude from git must be added to the project `.gitignore` file.
 Install the global .gitignore file via:
 
 ```bash
-curl https://raw.github.com/studio24/mac-setup/blob/main/global-gitignore/.gitignore > ~/.gitignore 
+curl https://raw.githubusercontent.com/studio24/mac-setup/main/global-gitignore/.gitignore > ~/.gitignore 
 git config --global core.excludesfile ~/.gitignore
 ```
 

--- a/dev-team.md
+++ b/dev-team.md
@@ -201,10 +201,15 @@ Host github.com
 We use a global [gitignore](https://www.atlassian.com/git/tutorials/saving-changes/gitignore) file to ignore IDE and OS files we don't want to commit to git. Any project files you want
 to exclude from git must be added to the project `.gitignore` file. 
 
-Install the global .gitignore file via:
+Download the global .gitignore file via:
 
-```bash
+```
 curl https://raw.githubusercontent.com/studio24/mac-setup/main/global-gitignore/.gitignore > ~/.gitignore 
+```
+
+And tell Git to use it via:
+
+```
 git config --global core.excludesfile ~/.gitignore
 ```
 


### PR DESCRIPTION
@AlanJIsaacson can you test the Global Git ignore file setup please, I've moved this to this repo for ease of maintenance. https://github.com/studio24/mac-setup/blob/hotfix/gitignore/dev-team.md#global-git-ignore-file