### PR TITLE
Update Mac setup docs with up to date instructions

### DIFF
--- a/dev-team.md
+++ b/dev-team.md
@@ -244,7 +244,7 @@ Install this via:
 git clone git@github.com:studio24/ssh-config.git ~/.ssh/ssh-config
 ```
 
-Create a `~/.ssh/config` file and add the following to it. 
+Create a `~/.ssh/config` file and add the following to it:
 
 ```
 Host *

--- a/dev-team.md
+++ b/dev-team.md
@@ -134,18 +134,6 @@ ZSH_THEME="agnoster"
 
 You then need to select a Powerline font in iTerm (Preferences > Profile > Text). `Noto Mono for Powerline` is recommended.
 
-## Deployer 6
-
-We use Composer to load Deployer for all new projects, this means your deployment commands should use `./vendor/bin/dep` to run Deployer.
-
-For older projects that still use Deployer 6, you can install Deployer globally using the instructions below. Please note this will only work with PHP 7.2+ or 8.0 (you need to use Deployer 7 for PHP 8.1+).
-
-```
-curl -LO https://deployer.org/releases/v6.9.0/deployer.phar 
-sudo mv deployer.phar /usr/local/bin/dep
-chmod +x /usr/local/bin/dep
-```
-
 ## PHPStorm
 
 When you setup PHPStorm install the following plugins:
@@ -162,7 +150,7 @@ Login to your JetBrains account to activate.
 Optional, install these if you want to use them:
 
 ```bash
-brew install --cask paw
+brew install --cask rapidapi
 brew install --cask textmate
 brew install --cask cyberduck
 brew install --cask visual-studio-code
@@ -256,11 +244,17 @@ Install this via:
 git clone git@github.com:studio24/ssh-config.git ~/.ssh/ssh-config
 ```
 
-Update your `~/.ssh/config` file:
+Create a `~/.ssh/config` file and add the following to it. 
 
 ```
+Host *
+	UseKeychain yes
+	IdentityFile ~/.ssh/id_rsa
+
 Include ssh-config/*.conf
 ```
+
+If your ssh key is not called `id_rsa`, use the correct name instead.
 
 You can test this by outputting all host shortcuts:
 
@@ -280,4 +274,4 @@ You can now toggle privileges in the dock at any time. Make sure you toggle priv
 
 ## Local development environment
 
-See [Local development environment](local-development.md)
+To install PHP, Composer and MySQL, see the [Local development environment](local-development.md) document.

--- a/local-development.md
+++ b/local-development.md
@@ -85,7 +85,7 @@ cd ~/ssl-certs
 mkcert local.host.dev
 ```
 
-Go into MAMP Pro and update and update your hosts entry to use the new certificate. Under the SSL tab set:
+Go into MAMP Pro and update your hosts entry to use the new certificate. Under the SSL tab set:
 
 * Certificate file: file ending `*.pem`, e.g. `~/ssl-certs/local.host.dev.pem`
 * Cerfificate key file: file ending `*-key.pm`, e.g. `~/ssl-certs/local.host.dev-key.pem`
@@ -99,7 +99,7 @@ PHP versioning is managed via MAMP Pro.
 
 In MAMP in the "PHP" section:
 
-* Click the "+" next to the PHP version and install an 8.1.* version of PHP so you have this available
+* Click the "+" next to the PHP version and install the PHP version you need to you have it available. MAMP will restart when you install a new version.
 * Tick "Activate command line shortcuts for the selected PHP version"
 * Tick "Also activate shortcut for Composer"
 * Under "What to log" ensure "All errors and warnings (E_ALL)" is selected
@@ -143,7 +143,7 @@ Please note you should be able to set the MySQL connection password for projects
 
 ### Accessing MySQL
 
-You can access MySQL locally via Sequel Ace.
+You can access MySQL locally via Table Plus.
 
 * Host: `127.0.0.1`
 * Username: `root`
@@ -175,3 +175,9 @@ If you want to migrate all of your Sequel Ace DB connections from your old Mac, 
 * Import on new Macbook
 
 **Note:** You will need to re-attach any SSH keys when accessing MySQL over SSH.
+
+### Migrating from Sequal Ace to TablePlus
+As of April 2024 [we are migrating away](https://3.basecamp.com/3091560/buckets/10590409/documents/7260701423) from using Sequel Ace to TablePlus for connecting to databases.
+
+You will need to download the latest version of TablePlus from the [TablePlus website](https://tableplus.com/download), and follow the instructions in the Basecamp message.
+

--- a/local-development.md
+++ b/local-development.md
@@ -99,7 +99,7 @@ PHP versioning is managed via MAMP Pro.
 
 In MAMP in the "PHP" section:
 
-* Click the "+" next to the PHP version and install the PHP version you need to you have it available. MAMP will restart when you install a new version.
+* Click the "+" next to the PHP version and install the PHP version you need to you have it available. MAMP will restart when you install the new version.
 * Tick "Activate command line shortcuts for the selected PHP version"
 * Tick "Also activate shortcut for Composer"
 * Under "What to log" ensure "All errors and warnings (E_ALL)" is selected

--- a/mac-setup.md
+++ b/mac-setup.md
@@ -35,7 +35,6 @@ All of the major software is installed (and updated) automatically by Addigy in 
 * Microsoft Teams (online meetings)
 * Microsoft To Do (todo app)
 * Mozilla Firefox (web browser)
-* Sequel Ace (database tool)
 * Slack (team chat)
 * SonicWall Mobile Connect (VPN)
 * Tick (time tracking)


### PR DESCRIPTION
This PR updates the Mac setup document with up to date instructions.

- Update references to Sequel Ace
- Added a section about TablePlus
- Rename `paw` to `rapidapi` since `paw` has been deprecated
- Remove the Deployer section since we are now using Deployer on a project basis, it doesn't need to be installed globally
- Update the section on the SSH aliases
- Fixed a typo
- Added a sentence about where to find PHP, MySQL and Composer instructions