### PR TITLE
Add info on how to support HTTPS on Firefox

### DIFF
--- a/dev-team.md
+++ b/dev-team.md
@@ -2,6 +2,19 @@
 
 Standard Mac setup for developers at Studio 24.
 
+- [Command Line Tools](#command-line-tools)
+- [Homebrew](#homebrew)
+- [PHP](#php)
+- [Software packages](#software-packages)
+- [PhpStorm](#phpstorm)
+- [iTerm](#iterm)
+- [SSH](#ssh)
+- [Git](#git)
+- [Oh My Zsh](#oh-my-zsh)
+- [Optional software](#optional-software)
+- [Local development environment](local-development.md)
+- [Configure 1Password for SSH access](1password-ssh.md)
+
 ## Command Line Tools
 
 You may need to re-install these when upgrading to a new OS version (you need to run this after upgrading to macOS Ventura). Toggle privileges (so you have admin rights) and run the following in terminal:
@@ -102,7 +115,14 @@ This installs the following CLI commands:
 3. Log in to JetBrains account (this opens a web browser)
 4. Go back to PhpStorm and activate your license
 
-## iTerm 
+When you set up PHPStorm you can install the following plugins (Settings > Plugins):
+
+* Laravel Idea 
+* Symfony Plugin
+
+Restart PHPStorm to activate plugins.
+
+## iTerm
 
 iTerm is a better terminal for the Mac.
 
@@ -280,17 +300,6 @@ ZSH_THEME="agnoster"
 ```
 
 You then need to select a Powerline font in iTerm (Preferences > Profile > Text). `Noto Mono for Powerline` is recommended.
-
-## PHPStorm
-
-When you setup PHPStorm install the following plugins (Settings > Plugins):
-
-* Laravel Idea (we have commercial licenses for the Dev Team)
-* Symfony Plugin
-
-Restart PHPStorm to activate plugins.
-
-Login to your JetBrains account to activate commercial plugins.
 
 ## Optional software
 

--- a/local-development.md
+++ b/local-development.md
@@ -3,6 +3,11 @@
 > [!NOTE]  
 > Please note we no longer use MAMP for local development and have moved to DDEV.
 
+- [Terminal](#terminal)
+- [Local SSL](#local-ssl)
+- [DDEV](#ddev)
+- [Using DDEV](https://github.com/studio24/dev-playbook/blob/main/ddev/using-ddev.md) (dev playbook) 
+
 ## Terminal
 
 Create Sites folder:
@@ -42,7 +47,8 @@ and store these in version control, so everyone uses the same version.
 
 OrbStack is a fast and simple alternative to Docker Desktop. We have team licenses.
 
-_Please note if you have Docker Desktop already installed we recommend uninstalling this first._
+> [!NOTE]  
+> Please note if you have Docker Desktop already installed we recommend uninstalling this first.
 
 Installation instructions:
 
@@ -57,8 +63,8 @@ Installation instructions:
 
 OrbStack should prompt when it needs updating (you'll need your Mac admin password to update software).
 
-_Note: to add a member to the Studio 24 Orbstack account admin users can go to the [dashboard](https://orbstack.dev/dashboard), 
-select Studio 24 organisation > Settings > Members > Invite a member._
+> [!NOTE]  
+> To add a member to the Studio 24 Orbstack account admin users can go to the [dashboard](https://orbstack.dev/dashboard), select Studio 24 organisation > Settings > Members > Invite a member.
 
 ### Installing DDEV
 
@@ -76,116 +82,6 @@ The first time you use DDEV it will ask:
 
 Answer no.
 
-## Upgrading DDEV
-
-```shell
-brew upgrade ddev/ddev/ddev
-```
-
 ## Using DDEV
 
-To start DDEV run:
-
-```shell
-ddev start
-```
-
-To view the website in your default browser:
-
-```shell
-ddev launch
-```
-
-To list all current projects:
-
-```shell
-ddev list
-```
-
-To restart DDEV (for example if config has changed) run:
-
-```shell
-ddev restart
-```
-
-To stop DDEV run
-
-```shell
-ddev stop
-```
-
-You can also shut down all DDEV projects via:
-
-```shell
-ddev poweroff
-```
-
-### Mailpit
-
-By default all emails sent from your website are captured in a tool called Mailpit, which allows you to review emails sent by the website.
-
-To open Mailpit run:
-
-```shell
-ddev mailpit
-```
-
-### Using a database
-
-To access the database via TablePlus:
-
-```shell
-ddev tableplus
-```
-
-Import a database via an SQL file:
-
-```shell
-ddev import-db < [filename]
-```
-
-Export SQL files for a database:
-
-```shell
-ddev export-db
-```
-
-### Xdebug
-
-Xdebug comes with it by default. To enable Xdebug run:
-
-```shell
-ddev xdebug on
-```
-
-To disable Xdebug:
-
-```shell
-ddev xdebug off
-```
-
-To toggle Xdebug on and off:
-
-```shell
-ddev xdebug toggle
-```
-
-Read instructions on [how to setup Xdebug in PHPstorm and VSCode](https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/).
-
-### Running commands in DDEV
-All commands must be run via ddev to ensure you are using the correct version of PHP. For example:
-
-```shell
-ddev composer install
-```
-
-Some [useful commands](https://ddev.readthedocs.io/en/stable/users/usage/cli/#lots-of-other-commands) from the DDEV docs:
-
-* `ddev composer` gives access to Composer
-* `ddev artisan` (Laravel only) gives direct access to the Laravel artisan CLI
-* `ddev console` (Symfony only) gives access to the Symfony console CLI
-* `ddev craft` (Craft CMS only) gives access to the Craft CLI
-* `ddev npm` gives direct access to the npm CLI
-* `ddev wp` (WordPress) give direct access to the WP CLI
-* `ddev ssh` takes you into the web container
-* `ddev exec [command]` executes a command inside the web container
+See [Using DDEV in the Dev Playbook](https://github.com/studio24/dev-playbook/blob/main/ddev/using-ddev.md).

--- a/local-development.md
+++ b/local-development.md
@@ -18,6 +18,20 @@ with GitHub. As an example, to clone this repo you'd use:
 git clone git@github.com:studio24/mac-setup.git
 ```
 
+## Local SSL
+
+You may need to install [mkcert](https://github.com/FiloSottile/mkcert) to ensure local SSLs work reliably in Firefox.
+
+```shell
+# You'll need to enter your Mac user and password to confirm this 
+brew install mkcert nss
+
+# You'll need to enter your admin user and password to confirm this
+mkcert -install
+```
+
+Restart Firefox once this is done to support local SSLs.
+
 ## DDEV
 
 [DDEV](https://ddev.readthedocs.io/en/stable/) is a simple development environment which uses Docker to manage local 

--- a/mac-setup.md
+++ b/mac-setup.md
@@ -4,20 +4,20 @@ The following is our standard Mac setup for all staff. The support team are on h
 
 - [Management tools](#management-tools)
 - [Mac boxes](#mac-boxes)
-- [1 - Initial boot](#1-initial-boot)
-- [2 - Support team setup](#2-support-team-setup)
-- [3 - Check for system updates](#3-check-for-system-updates)
-- [4 - Automatically downloading software](#4-automatically-downloading-software)
-- [5 - Setting up essential software](#5-setting-up-essential-software)
+- [1) Initial boot](#1-initial-boot)
+- [2) Support team setup](#2-support-team-setup)
+- [3) Check for system updates](#3-check-for-system-updates)
+- [4) Automatically downloading software](#4-automatically-downloading-software)
+- [5) Setting up essential software](#5-setting-up-essential-software)
   - [Email](#email)
   - [1Password](#1password)
   - [Slack](#slack)
-- [6 - Mac user passwords](#6-mac-user-passwords)
-- [7 - Setting up other software](#7-setting-up-other-software)
+- [6) Mac user passwords](#6-mac-user-passwords)
+- [7) Setting up other software](#7-setting-up-other-software)
   - [Finder](#finder)
   - [ESET endpoint security](#eset-endpoint-security)
   - [Web-based tools](#web-based-tools)
-- [8 - Further setup](#8-further-setup)
+- [8) Further setup](#8-further-setup)
 
 ## Management tools
 

--- a/mac-setup.md
+++ b/mac-setup.md
@@ -2,22 +2,22 @@
 
 The following is our standard Mac setup for all staff. The support team are on hand to help you, to get in touch with them either use Slack or call them on 44 (0)1223 328017.
 
-- [Management tools](#management-tools
+- [Management tools](#management-tools)
 - [Mac boxes](#mac-boxes)
-- 1) [Initial boot](#1-initial-boot)
-- 2) [Support team setup](#2-support-team-setup)
-- 3) [Check for system updates](#3-check-for-system-updates)
-- 4) [Automatically downloading software](#4-automatically-downloading-software)
-- 5) [Setting up essential software](#5-setting-up-essential-software)
+- [1 - Initial boot](#1-initial-boot)
+- [2 - Support team setup](#2-support-team-setup)
+- [3 - Check for system updates](#3-check-for-system-updates)
+- [4 - Automatically downloading software](#4-automatically-downloading-software)
+- [5 - Setting up essential software](#5-setting-up-essential-software)
   - [Email](#email)
   - [1Password](#1password)
   - [Slack](#slack)
-- 6) [Mac user passwords](#6-mac-user-passwords)
-- 7) [Setting up other software](#7-setting-up-other-software)
+- [6 - Mac user passwords](#6-mac-user-passwords)
+- [7 - Setting up other software](#7-setting-up-other-software)
   - [Finder](#finder)
   - [ESET endpoint security](#eset-endpoint-security)
   - [Web-based tools](#web-based-tools)
-- 8) [Further setup](#8-further-setup)
+- [8 - Further setup](#8-further-setup)
 
 ## Management tools
 

--- a/mac-setup.md
+++ b/mac-setup.md
@@ -2,6 +2,23 @@
 
 The following is our standard Mac setup for all staff. The support team are on hand to help you, to get in touch with them either use Slack or call them on 44 (0)1223 328017.
 
+- [Management tools](#management-tools
+- [Mac boxes](#mac-boxes)
+- 1) [Initial boot](#1-initial-boot)
+- 2) [Support team setup](#2-support-team-setup)
+- 3) [Check for system updates](#3-check-for-system-updates)
+- 4) [Automatically downloading software](#4-automatically-downloading-software)
+- 5) [Setting up essential software](#5-setting-up-essential-software)
+  - [Email](#email)
+  - [1Password](#1password)
+  - [Slack](#slack)
+- 6) [Mac user passwords](#6-mac-user-passwords)
+- 7) [Setting up other software](#7-setting-up-other-software)
+  - [Finder](#finder)
+  - [ESET endpoint security](#eset-endpoint-security)
+  - [Web-based tools](#web-based-tools)
+- 8) [Further setup](#8-further-setup)
+
 ## Management tools
 
 This process uses the following platforms to manage automated deployment:
@@ -13,7 +30,7 @@ This process uses the following platforms to manage automated deployment:
 
 All Mac systems purchased via the Apple Business account are automatically added to this process. Other MacOS and iOS systems can be added via serial or order number via the Apple Business Manager. Systems that are auto enrolled to this service will automatically download the agent and deploy according to the policy attached to them. Systems purchased from elsewhere will not be automatically enrolled.
 
-### Mac boxes
+## Mac boxes
 
 Please keep the Mac box (including the packing box) and store this in the Cambridge office. 
 
@@ -177,7 +194,7 @@ It's important to reset your admin password and store this in 1Password.
 
 You should also reset your password for your normal Mac user. Follow the same steps as above but for your normal Mac user.
 
-## 7) Setting up other software 
+## 7) Setting up other software
 
 Other software you'll need to create accounts for include the following. Invitations to create accounts for software and web-based tools will be sent to your email account. 
 
@@ -227,7 +244,7 @@ Once logged in as an admin user:
 * Log out as admin user
 * Log back in as your normal user
 
-### Access to web-based tools
+### Web-based tools
 
 Web-based tools you'll need to create accounts for are:
 


### PR DESCRIPTION
- Add local SSL setup (required for HTTPS on Firefox)
- Added content links at top of pages for Mac Setup, Dev Team, and Local Development to make finding content easier
- Moved Duplicated PHPStorm section on Dev team so this content sits together
- Removed Using DDEV instructions and instead linked to Dev playbook page on this